### PR TITLE
Support the SONAR encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Automated alignment process relies on the sentence embeddings models. Embeddings
   - pretty heavy weights — 1.8GB
   - supports 100+ languages
   - full list of supported languages can be found [here](https://arxiv.org/abs/2007.01852)
+- **SONAR** (Sentence-level multimOdal and laNguage-Agnostic Representations)
+  - Supports about 200 languages (approximately [these](https://github.com/facebookresearch/flores/tree/main/flores200))
+  - A large model (3 GB of weights)
+  - Ideally, requires you to indicate the source language explicitly
+  - Was originally released at [facebookresearch/SONAR](https://github.com/facebookresearch/SONAR) based on [fairseq2](https://github.com/facebookresearch/fairseq2), 
+  but here uses [a HuggingFace port](https://huggingface.co/cointegrated/SONAR_200_text_encoder).
+  
 
 ## Profit
 

--- a/src/lingtrain_aligner/model_dispatcher.py
+++ b/src/lingtrain_aligner/model_dispatcher.py
@@ -7,6 +7,7 @@ from lingtrain_aligner.sententense_transformers_models import (
     sentence_transformers_model_labse,
     sentence_transformers_model_xlm_100,
     rubert_tiny,
+    sonar,
 )
 
 models = {
@@ -14,5 +15,6 @@ models = {
     "sentence_transformer_multilingual_xlm_100": sentence_transformers_model_xlm_100,
     "sentence_transformer_multilingual_labse": sentence_transformers_model_labse,
     "rubert_tiny": rubert_tiny,
+    "sonar": sonar,
     # "use_multilingual_v3": use_multilingual_v3_model
 }

--- a/src/lingtrain_aligner/sententense_transformers_models.py
+++ b/src/lingtrain_aligner/sententense_transformers_models.py
@@ -3,6 +3,7 @@ import pickle
 
 from lingtrain_aligner.helper import lazy_property
 from sentence_transformers import SentenceTransformer
+from transformers.models.m2m_100.modeling_m2m_100 import M2M100Encoder
 import torch
 
 from tqdm.auto import tqdm
@@ -147,7 +148,7 @@ class SonarModel:
             )
         else:
             print("Loading SONAR model from Internet.")
-            _model = AutoModel.from_pretrained(
+            _model = M2M100Encoder.from_pretrained(
                 "cointegrated/SONAR_200_text_encoder", cache_dir="./models_cache"
             )
         return _model


### PR DESCRIPTION
# Why
SONAR encoder is highly multilingual (supporting 200 languages), and in the cross-lingual sentence alignment task, it is reported to outperform LaBSE (see e.g. the "Bitext mining" tab in the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard)).

# How
Just adding a wrapper over my HF port of the SONAR encoder.

Note: SONAR expects you to explicitly indicate the language code and prepends it to the text. The "default" code that works best is `ell_Grek`, because apparently it is the easiest for the model to ignore. However, for the maximum performance, it is recommended to pass the correct language code explicitly to the `embed` method. I didn't implement it, but I could do, if you approve of this idea

# Testing
I ran the Mockingbird rus-eng alignment notebook with SONAR as the indicated encoder, and observed the alignment quality comparable to that of LaBSE. 